### PR TITLE
It is more delightful to have code snippets by default.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -202,10 +202,10 @@ export VILE_PROJECT=my-project-name
 vile p -u
 ```
 
-You can also include code snippets and print detailed commit stats:
+To disable code snippet generation:
 
 ```sh
-vile p -usi
+vile p -us
 ```
 
 ### CI/CD Examples
@@ -232,7 +232,7 @@ checkout:
 
 test:
   post:
-    - vile p -usi -n
+    - vile p -u -n
 ```
 
 ### AppVeyor
@@ -268,7 +268,7 @@ install:
 
 test_script:
   - # run tests here
-  - vile p -usi -n
+  - vile p -u -n
 ```
 
 ### TravisCI
@@ -299,7 +299,7 @@ git:
 
 script:
   - # run tests here
-  - vile p -usi -n
+  - vile p -u -n
 ```
 
 ### Codeship

--- a/package.json
+++ b/package.json
@@ -137,6 +137,6 @@
     "test-ci-build": "node bin/test-ci-build",
     "tsc": "tsc",
     "typedoc": "typedoc",
-    "vile": "vile p -usi -x src.ts:lib.js,test.coffee:.test.js -n"
+    "vile": "vile p -u -x src.ts:lib.js,test.coffee:.test.js -n"
   }
 }

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -193,8 +193,7 @@ declare namespace vile {
     format?  : string;
     combine? : string;
     dontpostprocess? : boolean;
-    snippets? : boolean;
-    scores? : boolean;
+    skipsnippets? : boolean;
   }
 
   interface VileConfig {
@@ -380,7 +379,7 @@ declare namespace vile {
       format? : string;
       log?    : string;
       upload? : string;
-      scores? : boolean;
+      skipsnippets? : boolean;
     }
 
     export interface CLIModule {
@@ -400,10 +399,7 @@ declare namespace vile {
         auth : Auth
       ) => Bluebird<any>;
 
-      log : (
-        post_json : API.CommitStatus,
-        verbose : boolean
-      ) => void;
+      log : (post_json : API.CommitStatus) => void;
     }
   }
 }

--- a/src/cli/punish.ts
+++ b/src/cli/punish.ts
@@ -33,8 +33,7 @@ const wait_for = (ms : number, cb : (t : any) => void) => {
 
 const wait_for_done_status_and_log = (
   commit_id : number | null,
-  auth : vile.Auth,
-  verbose : boolean
+  auth : vile.Auth
 ) => {
   wait_for(COMMIT_STATUS_INTERVAL_TIME, (timer) => {
     service
@@ -60,7 +59,7 @@ const wait_for_done_status_and_log = (
           // TODO: handle when message is garbage (don't assume processing)
           if (message == util.API.COMMIT.FINISHED) {
             clearInterval(timer)
-            service.log(data, verbose)
+            service.log(data)
           } else if (message == util.API.COMMIT.FAILED) {
             clearInterval(timer)
             log_and_exit(data)
@@ -104,7 +103,7 @@ const publish = (
       } else if (commit_state == util.API.COMMIT.FAILED) {
         log_and_exit("Creating commit state is failed.")
       } else {
-        wait_for_done_status_and_log(commit_id, auth, opts.scores)
+        wait_for_done_status_and_log(commit_id, auth)
       }
     })
 }
@@ -190,13 +189,11 @@ const create = (cli : commander.ICommand) =>
     .option("-u, --upload [project_name]",
             "publish to vile.io (disables --gitdiff)- " +
               "alternatively, you can set a VILE_PROJECT env var")
-    .option("-s, --scores",
-            "show file scores and detailed stats")
     .option("-x, --combine [combine_def]",
             "combine file data from two directories into one path- " +
               "example: [src:lib,...] or [src.ts:lib.js,...]")
-    .option("-i, --snippets",
-            "add code snippets to issues")
+    .option("-s, --skipsnippets",
+            "don't include code snippets")
     .option("-d, --dontpostprocess",
             "don't post process data in any way (ex: adding ok issues)- " +
             "useful for per file checking- don't use with --upload")

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -391,6 +391,7 @@ const exec = (
   const allow = _.get(app_config, "allow", null)
   let plugins : vile.PluginList = custom_plugins
   const post_process = !opts.dontpostprocess
+  const allow_snippets = !opts.skipsnippets
 
   if (app_config.plugins) {
     plugins = _.uniq(plugins.concat(app_config.plugins))
@@ -399,11 +400,11 @@ const exec = (
   return (fs as any).readdirAsync(cwd_plugins_path())
     .filter(is_plugin)
     .then(execute_plugins(plugins, config, opts))
-    .then(post_process ? log_post_process("start") : passthrough)
-    .then(opts.snippets ? add_code_snippets() : passthrough)
-    .then(post_process ?
-          add_ok_issues(allow, ignore, opts.scores) : passthrough)
-    .then(post_process ? log_post_process("finish") : passthrough)
+    .then(post_process ? log_post_process("start")    : passthrough)
+    .then(post_process && allow_snippets ?
+                          add_code_snippets()         : passthrough)
+    .then(post_process ? add_ok_issues(allow, ignore) : passthrough)
+    .then(post_process ? log_post_process("finish")   : passthrough)
 }
 
 export = {

--- a/src/service.ts
+++ b/src/service.ts
@@ -67,8 +67,7 @@ const padded_file_score = (score : number) =>
   (score < 100 ? " " : "") + String(score) + "%"
 
 const log_summary = (
-  post_json : vile.API.CommitStatus,
-  verbose : boolean = false
+  post_json : vile.API.CommitStatus
 ) => {
   const score : number = _.get(post_json, "score", 100)
   const files : vile.API.CommitStatusFile[][] = _.get(
@@ -80,13 +79,11 @@ const log_summary = (
     .toString()
     .replace(/\.0*$/, "")
 
-  if (verbose) {
-    _.each(files, (file : vile.API.CommitStatusFile) => {
-      log.info(
-        `${padded_file_score(_.get(file, "score", 0))} => ` +
-        `${_.get(file, "path")}`)
-    })
-  }
+  _.each(files, (file : vile.API.CommitStatusFile) => {
+    log.info(
+      `${padded_file_score(_.get(file, "score", 0))} => ` +
+      `${_.get(file, "path")}`)
+  })
 
   log.info()
   log.info(`Score: ${score}%`)

--- a/test/system/cli.coffee
+++ b/test/system/cli.coffee
@@ -439,10 +439,23 @@ describe "cli blackbox testing", ->
     describe "code snippets", ->
       beforeEach -> process.chdir SNIPPET_DIR
 
-      it "passes it as expected", (done) ->
-        cli.exec "p -i -n -f json", (stdout) ->
-          expect(JSON.parse(stdout)).to.eql issues_snippets
-          done()
+      describe "without any extra options", ->
+        it "appends code snippets to code", (done) ->
+          cli.exec "p -n -f json", (stdout) ->
+            expect(JSON.parse(stdout)).to.eql issues_snippets
+            done()
+
+      describe "when --skipsnippets", ->
+        it "does not include snippets", (done) ->
+          cli.exec "p -n -s -f json", (stdout) ->
+            expect(JSON.parse(stdout)).to.not.match /snippet/
+            done()
+
+      describe "when --dontpostprocess", ->
+        it "does not include snippets", (done) ->
+          cli.exec "p -n -d -f json", (stdout) ->
+            expect(JSON.parse(stdout)).to.not.match /snippet/
+            done()
 
     describe "filtering via ignore", ->
       beforeEach -> process.chdir FILTER_IGNORE_DIR

--- a/test/unit/cli/punish.coffee
+++ b/test/unit/cli/punish.coffee
@@ -220,26 +220,12 @@ describe "cli/punish", ->
               service_commit_status_promise
                 .callsArgWith 0, commit_status_success_data
 
-            describe "not verbose logging", ->
-              beforeEach ->
-                commander.scores = false
-                cli_punish.create commander
+            beforeEach ->
+              cli_punish.create commander
 
-              it "clears the interval", ->
-                expect(clear_interval).to.have.been.calledWith fake_timer
-
-              it "logs the data", ->
-                expect(service.log).to.have.been
-                  .calledWith JSON.parse(commit_status_success_body).data, false
-
-            describe "verbose logging", ->
-              beforeEach ->
-                commander.scores = true
-                cli_punish.create commander
-
-              it "is set via opts.scores", ->
-                expect(service.log).to.have.been
-                  .calledWith JSON.parse(commit_status_success_body).data, true
+            it "logs detailed stats by default", ->
+              expect(service.log).to.have.been
+                .calledWith JSON.parse(commit_status_success_body).data
 
           describe "if commit failed", ->
             beforeEach ->

--- a/test/unit/service.coffee
+++ b/test/unit/service.coffee
@@ -124,9 +124,9 @@ describe "service", ->
         expect(log.info).to.have.been
           .calledWith commit_status.url
 
-    describe "when verbose", ->
+    describe "by default", ->
       beforeEach ->
-        service.log commit_status, true
+        service.log commit_status
 
       it "logs file info", ->
         expect(log.info).not.to.have.been
@@ -134,16 +134,4 @@ describe "service", ->
             "=> #{commit_status.files[0].path}"
         expect(log.info).not.to.have.been
           .calledWith " #{commit_status.files[1].score}% " +
-            "=> #{commit_status.files[1].path}"
-
-    describe "when not verbose", ->
-      beforeEach ->
-        service.log commit_status
-
-      it "does not log file info", ->
-        expect(log.info).not.to.have.been
-          .calledWith " #{commit_status.files[0].score}% " +
-            "=> #{commit_status.files[0].path}"
-        expect(log.info).not.to.have.been
-          .calledWith " #{commit_status.files[1].score}%  " +
             "=> #{commit_status.files[1].path}"


### PR DESCRIPTION
Note: this possibly creates a slightly negative UX
with users who may not want snippets of their code
uploaded, and who are unpleasantly surprised as a result.
However, services akin to vile.io clone repos and a
precedent exists, so IMO this should not be that surprising.

Even so, you can disable it with a flag, and
can easily delete any commit via the web
interface, including all of its data and snippets.