### PR TITLE
The spinner should be hidden if colors are disabled.

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,7 @@ const stop_spinner = () : void => {
 }
 
 const start_spinner = () : void => {
-  spin.start()
+  if (enable_colors) spin.start()
 }
 
 const update_spinner = (text : string) : void => {


### PR DESCRIPTION
Slipped through the cracks. start_spinner gets called and
enables it again.

Fixes #53 